### PR TITLE
47- changed _get_stats for SocialWork and IndividualCounselling

### DIFF
--- a/boris/reporting/reports/monthly_stats.py
+++ b/boris/reporting/reports/monthly_stats.py
@@ -138,6 +138,8 @@ class FirstContactCountDU(FirstContactCount):
     title = _(u'z toho s UD')
     filtering = (
         Q(person__client__primary_drug__isnull=False) &
+        Q(person__client__sex_partner=False) &
+        Q(person__client__close_person=False) &
         Q(content_type_model='incomeexamination')
     ) | (
         Q(person__anonymous__drug_user_type__in=(ANONYMOUS_TYPES.IV, ANONYMOUS_TYPES.NON_IV)) &

--- a/boris/services/models/basic.py
+++ b/boris/services/models/basic.py
@@ -309,12 +309,11 @@ class SocialWork(Service):
 
     @classmethod
     def _get_stats(cls, filtering, only_subservices=False, only_basic=False):
-        service = super(SocialWork, cls)._get_stats(filtering, only_subservices)
-        subservices = (_boolean_stats(cls, filtering, (
-            'social', 'legal', 'service_mediation', 'assistance_service', 'probation_supervision', 'other')))
+        boolean_stats = _boolean_stats(cls, filtering, ('social', 'legal', 'service_mediation',
+                                                        'assistance_service', 'probation_supervision', 'other'))
         if only_subservices:
-            return subservices
-        return service + subservices
+            return chain(boolean_stats)
+        return chain(((cls.service.title, sum(stat[1] for stat in boolean_stats)),),boolean_stats,)
 
 
 class UtilityWork(Service):
@@ -390,12 +389,11 @@ class IndividualCounselling(Service):
 
     @classmethod
     def _get_stats(cls, filtering, only_subservices=False, only_basic=False):
-        service = super(IndividualCounselling, cls)._get_stats(filtering, only_subservices)
-        subservices = (_boolean_stats(cls, filtering, (
-            'general', 'structured', 'pre_treatment', 'guarantee_interview', 'advice_to_parents')))
+        boolean_stats = _boolean_stats(cls, filtering, ('general', 'structured',
+                                                        'pre_treatment', 'guarantee_interview', 'advice_to_parents'))
         if only_subservices:
-            return subservices
-        return service + subservices
+            return chain(boolean_stats)
+        return chain(((cls.service.title, sum(stat[1] for stat in boolean_stats)),),boolean_stats,)
 
 
 class Address(Service):


### PR DESCRIPTION
_get_stats pro SocialWork a IndividualCounselling změněn tak, aby ve výstupu Výkony vracel na prvním místě součet pod-výkonů.